### PR TITLE
Feature grid modal key-navigation store update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5536,6 +5536,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -8712,9 +8717,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -10869,6 +10874,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+      "integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "react-query": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-2.15.1.tgz",
@@ -11603,11 +11624,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
@@ -13240,6 +13261,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/user-event": "^7.2.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-modal": "^3.11.2",
     "react-query": "^2.15.1",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",

--- a/src/App/App-actions.js
+++ b/src/App/App-actions.js
@@ -3,6 +3,7 @@ export const UPDATE_CURRENT_POST = "UPDATE_CURRENT_POST"
 export const UPDATE_IS_LOADING = "UPDATE_IS_LOADING"
 export const UPDATE_ERROR = "UPDATE_ERROR"
 export const RESET_CURRENT_POST = "RESET_CURRENT_POST"
+export const UPDATE_MEDIA_TYPE = "UPDATE_MEDIA_TYPE"
 
 export const updateError = (data) => {
   return {
@@ -12,7 +13,6 @@ export const updateError = (data) => {
 }
 
 export const updatePosts = (data) => {
-  console.log("updatePosts")
   return {
     type: UPDATE_POSTS,
     payload: data,
@@ -20,7 +20,6 @@ export const updatePosts = (data) => {
 }
 
 export const updateCurrentPost = (slug) => {
-  console.log("updateCurrentPost")
   if (slug)
     return async (dispatch, getState) => {
       const selectedPost = getState().App.posts.filter(
@@ -39,6 +38,12 @@ export const updateCurrentPostSuccess = (data) => {
 export const resetCurrentPost = (data) => {
   return {
     type: UPDATE_CURRENT_POST,
+    payload: data,
+  }
+}
+export const updateMediaType = (data) => {
+  return {
+    type: UPDATE_MEDIA_TYPE,
     payload: data,
   }
 }

--- a/src/App/App-reducer.js
+++ b/src/App/App-reducer.js
@@ -3,12 +3,14 @@ import {
   UPDATE_CURRENT_POST,
   RESET_CURRENT_POST,
   UPDATE_ERROR,
+  UPDATE_MEDIA_TYPE
 } from "./App-actions"
 
 const initialState = {
   error: null,
   posts: [],
   currentPost: [],
+  mediaType: 'image'
 }
 
 export default (state = initialState, { type, payload }) => {
@@ -32,6 +34,12 @@ export default (state = initialState, { type, payload }) => {
       return {
         ...state,
         currentPost: initialState.currentPost,
+      }
+
+    case UPDATE_MEDIA_TYPE:
+      return {
+        ...state,
+        mediaType: payload
       }
     default:
       return state

--- a/src/App/App-selectors.js
+++ b/src/App/App-selectors.js
@@ -2,16 +2,17 @@ export const selectError = (state) => state.App.error
 
 export const selectAllPosts = (state) => state.App.posts
 
-export const getCurrentPost = (slug) => (state) => {
-  state.App.currentPost &&
-    state.App.currentPost.filter((post) => post.slug === slug)
-}
+export const getCurrentPost = (state) => state.App.currentPost &&
+    state.App.currentPost
+
+
 
 export const selectTitles = (state) =>
-  Object.values(state.App.posts).map(({ title, slug, id }) => ({
+  Object.values(state.App.posts).map(({ title, slug, id, publishedAt }) => ({
     title,
     slug,
     id,
+    publishedAt: new Date(publishedAt).getFullYear()
   }))
 
 export const selectTitle = (state) =>
@@ -27,3 +28,5 @@ export const selectVideos = (state) =>
 export const selectImages = (state) =>
   state.App.currentPost.images &&
   state.App.currentPost.images.map((image) => image.url)
+
+  export const selectMediaType = (state) => state.App.mediaType

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -31,7 +31,7 @@ function App() {
 
   return (
     <div className="App">
-      <Navigation />
+      {/* <Navigation /> */}
       <MessageBox />
       {isLoading && <Loading />}
       <Switch>

--- a/src/App/App.scss
+++ b/src/App/App.scss
@@ -1,4 +1,6 @@
 .App {
+  height: 100vh;
+  width: 100vw;
   box-sizing: content-box;
   text-align: center;
 }

--- a/src/components/BodyText/BodyText.js
+++ b/src/components/BodyText/BodyText.js
@@ -1,15 +1,16 @@
 import React from "react"
 import { useSelector } from "react-redux"
-import { useParams } from "react-router-dom"
 import BlockContent from "@sanity/block-content-to-react"
+//components
+import ToggleButton from "../../components/ToggleButton/ToggleButton"
 //store
-import { selectBodyText } from "../../App/App-selectors"
+import { selectBodyText, getCurrentPost } from "../../App/App-selectors"
 //style
 import "./BodyText.scss"
 
 const BodyText = () => {
-  const { slug } = useParams()
   const bodyText = useSelector(selectBodyText)
+  const {video, images} = useSelector(getCurrentPost)
 
   return (
     <div className="BodyText">
@@ -19,6 +20,7 @@ const BodyText = () => {
           .map((block, i) => (
             <BlockContent key={i} blocks={block} serializers={{}} />
           ))}
+    {video && images ? <ToggleButton /> : null}
     </div>
   )
 }

--- a/src/components/BodyText/BodyText.js
+++ b/src/components/BodyText/BodyText.js
@@ -12,7 +12,7 @@ const BodyText = () => {
   const bodyText = useSelector(selectBodyText)
 
   return (
-    <div>
+    <div className="BodyText">
       {bodyText &&
         bodyText
           .filter(({ _type }) => _type === "block")

--- a/src/components/BodyText/BodyText.scss
+++ b/src/components/BodyText/BodyText.scss
@@ -2,12 +2,13 @@
 
 .BodyText {
   @include BodyText-grid;
-
-  // width: 18%;
-  // right: 5px;
-  // top: 10vh;
-  // padding: 8px;
-  // position: fixed;
-  // text-align: left;
-  // background: $primary;
+  text-align: left;
+  margin-right: 10px;
+  em {
+    font-style: $italic;
+  }
+  em:after {
+    content: "\a\a";
+    white-space: pre;
+  }
 }

--- a/src/components/BodyText/BodyText.scss
+++ b/src/components/BodyText/BodyText.scss
@@ -1,1 +1,13 @@
 @import "../../style/config";
+
+.BodyText {
+  @include BodyText-grid;
+
+  // width: 18%;
+  // right: 5px;
+  // top: 10vh;
+  // padding: 8px;
+  // position: fixed;
+  // text-align: left;
+  // background: $primary;
+}

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,0 +1,9 @@
+import React from "react"
+
+import "./Footer.scss"
+
+const Footer = () => {
+  return <div className="Footer">Footer</div>
+}
+
+export default Footer

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,0 +1,5 @@
+@import "../../style/config";
+
+.Footer {
+  @include Footer-grid;
+}

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { useSelector } from "react-redux"
 import { useParams } from "react-router-dom"
+import Modal from "react-modal"
 //store
 import { selectImages, getCurrentPost } from "../../App/App-selectors"
 //style
@@ -10,7 +11,14 @@ const Images = () => {
   const { slug } = useParams()
   const imageUrls = useSelector(selectImages)
   const [selectedImage, setSelectedImage] = useState("")
+  const [modalIsOpen, setModalIsOpen] = useState(false)
 
+  Modal.setAppElement("#root")
+
+  const indexOfImage = imageUrls && imageUrls.indexOf(selectedImage)
+  const lengthOfImageUrls = imageUrls && imageUrls.length
+
+  console.log(lengthOfImageUrls)
   // sets selectedImage fot first of the array if empty
   useEffect(() => {
     if (imageUrls && selectedImage === "") setSelectedImage(imageUrls[0])
@@ -23,28 +31,84 @@ const Images = () => {
     else setSelectedImage("")
   }, [imageUrls, selectedImage])
 
-  imageUrls && console.log("imageUrl amount", imageUrls.length)
+  // add event listener for keydown
+  useEffect(() => {
+    const handler = handleKeyDown(indexOfImage, lengthOfImageUrls)
+    window.addEventListener("keydown", handler)
+    return () => {
+      window.removeEventListener("keydown", handler)
+    }
+  }, [indexOfImage])
+
+  const handleKeyDown = (index, indexLength) => (event) => {
+    if (event.key === "ArrowLeft" && !event.repeat)
+      setSelectedImage(imageUrls[index - 1 < 0 ? indexLength - 1 : index - 1])
+    else if (event.key === "ArrowRight" && !event.repeat)
+      setSelectedImage(imageUrls[(index + 1) % indexLength])
+    else return
+  }
+
+  const selectedThumbnail = (url) => {
+    if (url === selectedImage) {
+      return { opacity: 0.5 }
+    }
+  }
 
   return (
     <div className="Images">
+      <Modal
+        style={{
+          overlay: {
+            position: "fixed",
+            top: "0px",
+            left: "0px",
+            right: "0px",
+            bottom: "0px",
+            backgroundColor: "rgba(0, 0, 0, 0.75)",
+          },
+          content: {
+            position: "absolute",
+            top: "30px",
+            left: "30px",
+            right: "30px",
+            bottom: "30px",
+            border: "0px",
+            background: "white",
+            backgroundColor: "black",
+            overflow: "hidden",
+            WebkitOverflowScrolling: "touch",
+            borderRadius: "4px",
+            outline: "none",
+            padding: "0px",
+            display: "flex",
+            alignContent: "center",
+            justifyContent: "center",
+          },
+        }}
+        isOpen={modalIsOpen}
+        onRequestClose={() => setModalIsOpen(false)}
+      >
+        <img
+          src={selectedImage}
+          style={{ maxWidth: "100%", maxHeight: "100%", overflow: "hidden" }}
+        ></img>
+      </Modal>
       <div className="Images__nav">
         {imageUrls && imageUrls.length > 1
           ? imageUrls.map((image, i) => (
-              <div
+              <img
+                src={image}
                 className="Images__nav__button"
                 key={i}
                 onClick={() => setSelectedImage(image)}
-                style={{ backgroundImage: `url(${image})` }}
-              />
+                style={selectedThumbnail(image)}
+              ></img>
             ))
           : null}
       </div>
 
-      <div
-        className="Images__selected"
-        /*style={{ backgroundImage: `url(${selectedImage})` }}*/
-      >
-        <img src={selectedImage}></img>
+      <div className="Images__selected">
+        <img src={selectedImage} onClick={() => setModalIsOpen(true)}></img>
       </div>
     </div>
   )

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux"
 import { useParams } from "react-router-dom"
 import Modal from "react-modal"
 //store
-import { selectImages, getCurrentPost } from "../../App/App-selectors"
+import { selectImages } from "../../App/App-selectors"
 //style
 import "./Images.scss"
 
@@ -18,7 +18,14 @@ const Images = () => {
   const indexOfImage = imageUrls && imageUrls.indexOf(selectedImage)
   const lengthOfImageUrls = imageUrls && imageUrls.length
 
-  console.log(lengthOfImageUrls)
+  const handleKeyDown = (index, indexLength) => (event) => {
+    if (event.key === "ArrowLeft" && !event.repeat)
+      setSelectedImage(imageUrls[index - 1 < 0 ? indexLength - 1 : index - 1])
+    else if (event.key === "ArrowRight" && !event.repeat)
+      setSelectedImage(imageUrls[(index + 1) % indexLength])
+    else return
+  }
+
   // sets selectedImage fot first of the array if empty
   useEffect(() => {
     if (imageUrls && selectedImage === "") setSelectedImage(imageUrls[0])
@@ -38,15 +45,8 @@ const Images = () => {
     return () => {
       window.removeEventListener("keydown", handler)
     }
-  }, [indexOfImage])
+  }, [indexOfImage, lengthOfImageUrls, handleKeyDown])
 
-  const handleKeyDown = (index, indexLength) => (event) => {
-    if (event.key === "ArrowLeft" && !event.repeat)
-      setSelectedImage(imageUrls[index - 1 < 0 ? indexLength - 1 : index - 1])
-    else if (event.key === "ArrowRight" && !event.repeat)
-      setSelectedImage(imageUrls[(index + 1) % indexLength])
-    else return
-  }
 
   const selectedThumbnail = (url) => {
     if (url === selectedImage) {
@@ -91,6 +91,7 @@ const Images = () => {
         <img
           src={selectedImage}
           style={{ maxWidth: "100%", maxHeight: "100%", overflow: "hidden" }}
+          alt=""
         ></img>
       </Modal>
       <div className="Images__nav">
@@ -102,13 +103,14 @@ const Images = () => {
                 key={i}
                 onClick={() => setSelectedImage(image)}
                 style={selectedThumbnail(image)}
+                alt=""
               ></img>
             ))
           : null}
       </div>
 
       <div className="Images__selected">
-        <img src={selectedImage} onClick={() => setModalIsOpen(true)}></img>
+        <img src={selectedImage} onClick={() => setModalIsOpen(true)} alt=""></img>
       </div>
     </div>
   )

--- a/src/components/Images/Images.js
+++ b/src/components/Images/Images.js
@@ -23,21 +23,27 @@ const Images = () => {
     else setSelectedImage("")
   }, [imageUrls, selectedImage])
 
+  imageUrls && console.log("imageUrl amount", imageUrls.length)
+
   return (
     <div className="Images">
       <div className="Images__nav">
-        {imageUrls &&
-          imageUrls.map((image, i) => (
-            <div
-              className="Images__nav__buttons"
-              key={i}
-              onClick={() => setSelectedImage(image)}
-              style={{ backgroundImage: `url(${image})` }}
-            />
-          ))}
+        {imageUrls && imageUrls.length > 1
+          ? imageUrls.map((image, i) => (
+              <div
+                className="Images__nav__button"
+                key={i}
+                onClick={() => setSelectedImage(image)}
+                style={{ backgroundImage: `url(${image})` }}
+              />
+            ))
+          : null}
       </div>
 
-      <div className="Images__selected">
+      <div
+        className="Images__selected"
+        /*style={{ backgroundImage: `url(${selectedImage})` }}*/
+      >
         <img src={selectedImage}></img>
       </div>
     </div>

--- a/src/components/Images/Images.scss
+++ b/src/components/Images/Images.scss
@@ -1,32 +1,39 @@
 @import "../../style/config";
 
 .Images {
-  margin-left: 25%;
-  margin-right: 25%;
-  // width: 50%;
-  display: flex;
-  flex-direction: row;
-  // flex: 1;
-
-  &__nav {
-    flex: 1;
-    // height: 100%;
-    margin-right: 10px;
-
-    &__buttons {
-      width: 100%;
-      height: 2em;
-      margin-bottom: 5px;
-      background-size: cover;
-      background-position: 50% 50%;
-    }
-  }
+  @include Images-grid;
 
   &__selected {
-    flex: 7;
-    // padding: 0px 10px;
+    width: 100%;
+    height: 100%;
     img {
-      width: 100%;
+      max-height: 100%;
+      max-width: 100%;
     }
   }
+
+  // &__nav {
+  //   flex: 1;
+  //   margin-right: 10px;
+
+  //   &__button {
+  //     margin-bottom: 5%;
+  //     background-size: cover;
+  //     background-position: 50% 50%;
+  //   }
+  //   &__button:after {
+  //     content: "";
+  //     display: block;
+  //     padding-bottom: 100%;
+  //   }
+  // }
+
+  // &__selected {
+  //   flex: 12;
+  //   // padding: 0px 10px;
+  //   img {
+  //     width: 100%;
+  //     height: auto;
+  //   }
+  // }
 }

--- a/src/components/Images/Images.scss
+++ b/src/components/Images/Images.scss
@@ -3,37 +3,35 @@
 .Images {
   @include Images-grid;
 
+  grid-template-rows: 9fr 1fr;
+  display: flex;
+  flex-direction: column;
+
   &__selected {
+    display: flex;
     width: 100%;
     height: 100%;
+    align-items: center;
+    justify-content: center;
+    order: 1;
+    flex: 9;
     img {
       max-height: 100%;
       max-width: 100%;
     }
   }
 
-  // &__nav {
-  //   flex: 1;
-  //   margin-right: 10px;
+  &__nav {
+    display: flex;
+    order: 2;
+    flex: 1;
+    justify-content: space-evenly;
+    align-items: flex-end;
 
-  //   &__button {
-  //     margin-bottom: 5%;
-  //     background-size: cover;
-  //     background-position: 50% 50%;
-  //   }
-  //   &__button:after {
-  //     content: "";
-  //     display: block;
-  //     padding-bottom: 100%;
-  //   }
-  // }
-
-  // &__selected {
-  //   flex: 12;
-  //   // padding: 0px 10px;
-  //   img {
-  //     width: 100%;
-  //     height: auto;
-  //   }
-  // }
+    img {
+      width: auto;
+      height: 80%;
+      padding: 5px;
+    }
+  }
 }

--- a/src/components/Images/Images.scss
+++ b/src/components/Images/Images.scss
@@ -25,13 +25,13 @@
     display: flex;
     order: 2;
     flex: 1;
-    justify-content: space-evenly;
+    justify-content: center;
     align-items: flex-end;
 
     img {
       width: auto;
       height: 80%;
-      padding: 5px;
+      padding: 1px;
     }
   }
 }

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from "react"
-import { useParams } from "react-router-dom"
+import React from "react"
 import { NavLink } from "react-router-dom"
 
 // styles

--- a/src/components/Title/Title.js
+++ b/src/components/Title/Title.js
@@ -1,18 +1,17 @@
 import React from "react"
 import { useSelector } from "react-redux"
-import { useParams } from "react-router-dom"
 //store
 import { selectTitle } from "../../App/App-selectors"
 //style
 import "./Title.scss"
 
 const Title = () => {
-  const { slug } = useParams()
   const title = useSelector(selectTitle)
+
 
   return (
     <div className="Title">
-      <div>{title}</div>
+      <h1>{title}</h1>
     </div>
   )
 }

--- a/src/components/Title/Title.scss
+++ b/src/components/Title/Title.scss
@@ -2,4 +2,20 @@
 
 .Title {
   @include Title-grid;
+  font-size: 20pt;
+  font-family: $fontSecondary;
+  // display: flex;
+  // align-items: flex-end;
+  // justify-content: center;
+  h1 {
+    width: auto;
+    height: 100%;
+    padding-top: 10px;
+    left: 0;
+    right: 0;
+    top: 0;
+    margin: auto;
+    position: absolute;
+    pointer-events: none;
+  }
 }

--- a/src/components/Title/Title.scss
+++ b/src/components/Title/Title.scss
@@ -1,5 +1,5 @@
 @import "../../style/config";
 
 .Title {
-  left: 0px;
+  @include Title-grid;
 }

--- a/src/components/ToggleButton/ToggleButton.js
+++ b/src/components/ToggleButton/ToggleButton.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { useSelector , useDispatch} from "react-redux"
+//store
+import {selectMediaType } from "../../App/App-selectors"
+import { updateMediaType} from "../../App/App-actions"
+
+const ToggleButton = () => {
+  const dispatch = useDispatch()
+  const mediaType = useSelector(selectMediaType)
+
+const toggleMediaType = () => mediaType === "image" ? "video" : "image"
+
+return (
+    <div>
+      <button onClick={() => dispatch(updateMediaType(toggleMediaType()))}>{toggleMediaType()}</button>
+    </div>
+  )
+}
+export default ToggleButton

--- a/src/components/VideoPlayer/VideoPlayer.js
+++ b/src/components/VideoPlayer/VideoPlayer.js
@@ -1,13 +1,11 @@
 import React from "react"
 import { useSelector } from "react-redux"
-import { useParams } from "react-router-dom"
 //store
 import { selectVideos } from "../../App/App-selectors"
 //style
 import "./VideoPlayer.scss"
 
 const VideoPlayer = () => {
-  const { slug } = useParams()
   const videoUrls = useSelector(selectVideos)
 
   return (

--- a/src/components/WorkIndex/WorkIndex.js
+++ b/src/components/WorkIndex/WorkIndex.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { useSelector, useDispatch } from "react-redux"
+import { useSelector } from "react-redux"
 import { Link } from "react-router-dom"
 
 //store
@@ -9,13 +9,20 @@ import "./WorkIndex.scss"
 
 const WorkIndex = () => {
   const titles = useSelector(selectTitles)
+  const uniqueYears = titles && [...new Set(titles.map(title => title.publishedAt))].sort((a, b) => b-a)
 
   return (
     <div className="WorkIndex">
-      {titles.map((title) => (
-        <Link key={title.id} to={`/${title.slug}`}>
-          {title.title}
-        </Link>
+      {uniqueYears.map((year, i) => (
+        <div key={i}>
+          <p>{year}</p>
+          {titles.length && titles
+            .filter(({publishedAt}) => publishedAt === year)
+            .map(({title, id, slug}) =>   
+            <Link key={id} to={`/${slug}`}>
+            - {title}
+          </Link>)}
+        </div>
       ))}
     </div>
   )

--- a/src/components/WorkIndex/WorkIndex.scss
+++ b/src/components/WorkIndex/WorkIndex.scss
@@ -1,12 +1,12 @@
 @import "../../style/config";
 
 .WorkIndex {
-  left: 5px;
-  top: 5vh;
+  @include WorkIndex-grid;
+
   padding: 8px;
-  position: fixed;
+  // position: fixed;
   text-align: left;
-  background: $primary;
+  // background: $primary;
   a {
     display: block;
     line-height: 20px;

--- a/src/components/WorkIndex/WorkIndex.scss
+++ b/src/components/WorkIndex/WorkIndex.scss
@@ -2,13 +2,14 @@
 
 .WorkIndex {
   @include WorkIndex-grid;
-
-  padding: 8px;
-  // position: fixed;
   text-align: left;
-  // background: $primary;
+  font-size: $bodyRegular;
+  p {
+    font-style: $italic;
+  }
   a {
     display: block;
     line-height: 20px;
+    text-decoration: none;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { BrowserRouter as Router, Route } from "react-router-dom"
+import { BrowserRouter as Router } from "react-router-dom"
 import { Provider } from "react-redux"
 //components
 import App from "./App/App"

--- a/src/index.scss
+++ b/src/index.scss
@@ -90,7 +90,7 @@ video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
-  overflow-y: hidden;
+  overflow: hidden;
 }
 /* HTML5 display-role reset for older browsers */
 article,

--- a/src/pages/Homepage/Homepage.js
+++ b/src/pages/Homepage/Homepage.js
@@ -9,8 +9,8 @@ import BodyText from "../../components/BodyText/BodyText"
 import Title from "../../components/Title/Title"
 import Footer from "../../components/Footer/Footer"
 //Store
-import { updateCurrentPost } from "../../App/App-actions"
-import { selectAllPosts } from "../../App/App-selectors"
+import { updateCurrentPost, updateMediaType } from "../../App/App-actions"
+import { selectAllPosts, getCurrentPost } from "../../App/App-selectors"
 //styling
 import "./Homepage.scss"
 
@@ -18,10 +18,17 @@ const Homepage = () => {
   const dispatch = useDispatch()
   const { slug } = useParams()
   const posts = useSelector(selectAllPosts)
+  const { images} = useSelector(getCurrentPost)
 
+  //update current post
   useEffect(() => {
     if (posts && posts.length > 0) dispatch(updateCurrentPost(slug))
   }, [slug, posts, dispatch])
+
+  //if no images available set mediaType to video
+  useEffect(() => {
+    if(posts && !images) dispatch(updateMediaType("video"))
+  }, [posts, images, dispatch])
 
   return (
     <div className="Homepage">
@@ -29,8 +36,8 @@ const Homepage = () => {
       <div className="Homepage__Logo">Logo</div>
       <Title />
       <WorkIndex />
-      {/* <VideoPlayer /> */}
-      <Images />
+      <Images /> 
+      <VideoPlayer />
       <BodyText />
       <Footer />
     </div>

--- a/src/pages/Homepage/Homepage.js
+++ b/src/pages/Homepage/Homepage.js
@@ -7,6 +7,7 @@ import VideoPlayer from "../../components/VideoPlayer/VideoPlayer"
 import Images from "../../components/Images/Images"
 import BodyText from "../../components/BodyText/BodyText"
 import Title from "../../components/Title/Title"
+import Footer from "../../components/Footer/Footer"
 //Store
 import { updateCurrentPost } from "../../App/App-actions"
 import { selectAllPosts } from "../../App/App-selectors"
@@ -24,12 +25,14 @@ const Homepage = () => {
 
   return (
     <div className="Homepage">
-      <h1>Works</h1>
+      <div className="Homepage__Navigation">Navigatie</div>
+      <div className="Homepage__Logo">Logo</div>
       <Title />
       <WorkIndex />
-      <VideoPlayer />
+      {/* <VideoPlayer /> */}
       <Images />
       <BodyText />
+      <Footer />
     </div>
   )
 }

--- a/src/pages/Homepage/Homepage.scss
+++ b/src/pages/Homepage/Homepage.scss
@@ -2,11 +2,15 @@
 
 .Homepage {
   // background-color: aqua;
-  height: 100vh;
-  width: 100vw;
+  max-height: 100vh;
+  max-width: 90%;
   display: grid;
+  margin: auto;
   grid-gap: 10px;
-  grid-template: 1fr 12fr 1fr / 2fr 7fr 3fr;
+  grid-template: 1fr 12fr 1fr / 3fr 6fr 3fr;
+  font-family: $fontPrimary;
+  font-weight: $light;
+  font-size: $bodyRegular;
 
   &__Navigation {
     // background-color: red;

--- a/src/pages/Homepage/Homepage.scss
+++ b/src/pages/Homepage/Homepage.scss
@@ -1,7 +1,7 @@
 @import "../../style/config";
 
 .Homepage {
-  background-color: aqua;
+  // background-color: aqua;
   height: 100vh;
   width: 100vw;
   display: grid;
@@ -9,13 +9,13 @@
   grid-template: 1fr 12fr 1fr / 2fr 7fr 3fr;
 
   &__Navigation {
-    background-color: red;
+    // background-color: red;
     grid-row: 1;
     grid-column: 1;
   }
 
   &__Logo {
-    background-color: darkgreen;
+    // background-color: darkgreen;
     grid-row: 1;
     grid-column: 3;
   }

--- a/src/pages/Homepage/Homepage.scss
+++ b/src/pages/Homepage/Homepage.scss
@@ -1,5 +1,22 @@
 @import "../../style/config";
 
 .Homepage {
-  padding: 10px;
+  background-color: aqua;
+  height: 100vh;
+  width: 100vw;
+  display: grid;
+  grid-gap: 10px;
+  grid-template: 1fr 12fr 1fr / 2fr 7fr 3fr;
+
+  &__Navigation {
+    background-color: red;
+    grid-row: 1;
+    grid-column: 1;
+  }
+
+  &__Logo {
+    background-color: darkgreen;
+    grid-row: 1;
+    grid-column: 3;
+  }
 }

--- a/src/pages/Homepage/grid.scss
+++ b/src/pages/Homepage/grid.scss
@@ -15,6 +15,11 @@
   grid-row: 2;
   grid-column: 2;
 }
+@mixin Video-grid {
+  // background-color: orange;
+  grid-row: 2;
+  grid-column: 2;
+}
 @mixin BodyText-grid {
   // background-color: darkorchid;
   grid-row: 2;

--- a/src/pages/Homepage/grid.scss
+++ b/src/pages/Homepage/grid.scss
@@ -1,27 +1,27 @@
 @mixin Title-grid {
-  background-color: blue;
+  // background-color: blue;
   grid-row: 1;
   grid-column: 2;
 }
 @mixin WorkIndex-grid {
-  background-color: magenta;
+  // background-color: magenta;
   grid-row: 2;
   grid-column: 1;
 }
 @mixin VideoPlayer-grid {
 }
 @mixin Images-grid {
-  background-color: orange;
+  // background-color: orange;
   grid-row: 2;
   grid-column: 2;
 }
 @mixin BodyText-grid {
-  background-color: darkorchid;
+  // background-color: darkorchid;
   grid-row: 2;
   grid-column: 3;
 }
 @mixin Footer-grid {
-  background-color: gray;
+  // background-color: gray;
   grid-row: 3;
   grid-column: 1 / -1;
 }

--- a/src/pages/Homepage/grid.scss
+++ b/src/pages/Homepage/grid.scss
@@ -1,0 +1,27 @@
+@mixin Title-grid {
+  background-color: blue;
+  grid-row: 1;
+  grid-column: 2;
+}
+@mixin WorkIndex-grid {
+  background-color: magenta;
+  grid-row: 2;
+  grid-column: 1;
+}
+@mixin VideoPlayer-grid {
+}
+@mixin Images-grid {
+  background-color: orange;
+  grid-row: 2;
+  grid-column: 2;
+}
+@mixin BodyText-grid {
+  background-color: darkorchid;
+  grid-row: 2;
+  grid-column: 3;
+}
+@mixin Footer-grid {
+  background-color: gray;
+  grid-row: 3;
+  grid-column: 1 / -1;
+}

--- a/src/style/_config.scss
+++ b/src/style/_config.scss
@@ -1,1 +1,4 @@
+// Homepage grids
+@import "../../pages/Homepage/grid.scss";
+
 $primary: white;

--- a/src/style/_config.scss
+++ b/src/style/_config.scss
@@ -1,4 +1,24 @@
 // Homepage grids
 @import "../../pages/Homepage/grid.scss";
+@import "./typefaces";
 
+//colors
 $primary: white;
+
+// fontfaces
+$fontPrimary: "Roboto Condensed", sans-serif;
+$fontSecondary: "Secular One", sans-serif;
+
+//font weights
+$light: 300;
+$regular: 400;
+$bold: 700;
+
+// font size
+$bodySmall: 9pt;
+$bodyRegular: 12pt;
+
+//font styles
+$regular: none;
+$italic: italic;
+$bold: bold;

--- a/src/style/_typefaces.scss
+++ b/src/style/_typefaces.scss
@@ -1,0 +1,3 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap");
+
+@import url("https://fonts.googleapis.com/css2?family=Secular+One&display=swap");


### PR DESCRIPTION
# Multiple new features and improvements (WIP)

- [grid](#grid)
- [Modal](#Modal)
- [keyboard navigation](#keyboard-navigation)
- [mediaType store update](#mediaType-store-update)
- [Styling](#Styling)

## grid
I implemented css grid to Homepage.js to have more control of the design. My goal is to have a non scrollable page (desktop) with responsive components filling the grids space.

![Screenshot 2020-10-10 at 02 41 42](https://user-images.githubusercontent.com/65892566/95641483-de91aa00-0aa2-11eb-8f82-c2c4f0a90661.png)

Top-left: Homepage/About navigation(WIP) | Top-center: Work title | Top-right: Logo
Center-left: Work titles navigation | Center-center: Images navigation | Center-right: Work text
Bottom: Footer

I created a grid.scss file to create @mixins that I can give to separate components

## Modal
I want the user to be able to click an image to view fullscreen, I use [React-Modal](https://github.com/reactjs/react-modal)
for this. I still need to figure out how to style this using scss. For now I copied the default style and pasted it in the Modal style and edited it there. You can leave Modal view by clicking next to it or pressing 'esc'
![Screenshot 2020-10-10 at 02 54 58](https://user-images.githubusercontent.com/65892566/95641686-05041500-0aa4-11eb-9444-2af482b006e7.png)

## keyboard-navigation 
To enhance image navigation I used `window.addEventListener("keydown", handler)` to fires a callback function that shifts trough the array of images, with each click setting a new selectedImage. This is mostly useful when the Modal is activated.
![Oct-10-2020 03-02-27](https://user-images.githubusercontent.com/65892566/95641861-1863b000-0aa5-11eb-80ab-689c35b32485.gif)


## mediaType store update
I want the user to be able to switch (if possible) from images to videos, to do this I added the initial state of 'mediaType', that is set to 'images' by default. If a work contains video as well, a button appears that enables the user to toggle between videos/images. The button wont render if the work does not contain video.
If a work only contains video but no images, an action if fired to set mediaType to 'Video'.
I want the Video/Images components only to render when their concerned mediaType is represented in the Redux store.
![Oct-10-2020 02-31-08](https://user-images.githubusercontent.com/65892566/95642001-10584000-0aa6-11eb-8063-7ba684aeade4.gif)

## styling
I added 2 fontfaces and some variables in the _config.scss file. The styling is basically how I want it now, I'll continue to improve styling after necessary features are implemented.

My goal is to make is:
- some animation when navigating images
- max amount of images in the navigation (creating my own 'carousel')
- foldable 'Years' in the work index, hiding projects under the year it's made.
- animation when a user clicks another work.
- animation when a user opens/closes the modal
